### PR TITLE
fix: spawn de bebidas BR nas maquinas

### DIFF
--- a/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
+++ b/Resources/Prototypes/Catalog/ReagentDispensers/beverage.yml
@@ -20,6 +20,7 @@
   - JuiceOrange
   - JuiceLime
   - JuiceWatermelon
+  - Guarana
   ###Hacked
   #- Fourteen Loko
   #- GrapeSoda
@@ -45,6 +46,7 @@
   - Cognac
   - Ale
   - Mead
+  - Cachaca
   ###Hacked
   #- Goldschlager
   #- Patron

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/boozeomat.yml
@@ -11,8 +11,10 @@
     DrinkAleBottleFull: 5
     DrinkBeer: 5 # Needs to be renamed DrinkBeerBottleFull
     DrinkBlueCuracaoBottleFull: 2
+    DrinkCachacaBottleFull: 5
     DrinkCognacBottleFull: 4
     DrinkColaBottleFull: 4
+    DrinkGuaranaBottleFull: 5
     DrinkCreamCarton: 5
     DrinkGinBottleFull: 3
     DrinkGoldschlagerBottleFull: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/cola.yml
@@ -2,6 +2,7 @@
   id: RobustSoftdrinksInventory
   startingInventory:
     DrinkColaCan: 2
+    DrinkGuaranaCan: 3
     DrinkEnergyDrinkCan: 2
     DrinkGrapeCan: 3
     DrinkRootBeerCan: 2

--- a/Resources/Prototypes/EstacaoPirata/Reagents/Consumable/Drinks/alcohol.yml
+++ b/Resources/Prototypes/EstacaoPirata/Reagents/Consumable/Drinks/alcohol.yml
@@ -6,7 +6,9 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: cachaca
   color: "#d1d1d155"
-  spritePath: ginvodkaglass.rsi
+  metamorphicSprite:
+    sprite: Objects/Consumable/Drinks/ginvodkaglass.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:
@@ -24,7 +26,9 @@
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: caipirinha
   color: "#87ffa9"
-  spritePath: caipirinhaglass.rsi
+  metamorphicSprite:
+    sprite: EstacaoPirata/Objects/Consumable/Drinks/caipirinhaglass.rsi
+    state: icon
   metabolisms:
     Drink:
       effects:

--- a/Resources/Prototypes/EstacaoPirata/Recipes/Reactions/drinks.yml
+++ b/Resources/Prototypes/EstacaoPirata/Recipes/Reactions/drinks.yml
@@ -2,10 +2,10 @@
   id: Caipirinha
   reactants:
     JuiceLime:
-      amount: 2
+      amount: 1
     Cachaca:
-      amount: 2
+      amount: 1
     Sugar:
       amount: 1
   products:
-    Caipirinha: 5
+    Caipirinha: 3


### PR DESCRIPTION


<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
- Spawn de bebidas BR nas maquinas
   - BoozeDispenser, SodaDispenser, Boozeomat, Robustsoftdrinks
- Mudado receita da Caipirinha
- Corrigido sprite da Caipirinha no copo
- Corrigido sprite da Cachaça no copo


![image](https://user-images.githubusercontent.com/1398269/226787327-72be97ba-75b5-4c78-821a-5bc68922816c.png)

