### PR TITLE
altera luz do capacete da hardsuit da eng

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -74,7 +74,7 @@
   - type: Clothing
     sprite: Clothing/Head/Hardsuits/engineering.rsi
   - type: PointLight
-    color: "#ffdbad"
+    color: "#82e1aa"
   - type: PressureProtection
     highPressureMultiplier: 0.1
     lowPressureMultiplier: 1000


### PR DESCRIPTION
Antes a luz era branca, não combinando com a sprite, agora é assim.

![image](https://github.com/rbertoche/space-station-14/assets/117521143/71fc9bd4-a060-49b3-a7e6-06f8ab725c7b)
