### PR TITLE
modifica evento de zumbis midround

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -375,7 +375,7 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 50
+      max: 5
       playerRatio: 10
       blacklist:
         components:

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -368,14 +368,14 @@
   components:
   - type: StationEvent
     earliestStart: 90
-    minimumPlayers: 25
+    minimumPlayers: 50
     weight: 2
     duration: 1
   - type: ZombieRule
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 3
+      max: 50
       playerRatio: 10
       blacklist:
         components:


### PR DESCRIPTION

## About the PR
Modifica quantidade de jogadores necessários para a Gamerule "ZombieOutbrak"

## Why / Balance
Nao remove a possibilidade de zumbis em rounds secret, porém permite apenas para high pop

## Technical details
mínimo necessário: 25 aumentado para 50
máximo de antags: 5 
