### PR TITLE
Adiciona cabelo e barba para a raça Moth

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -7,6 +7,8 @@
   components:
   - type: HumanoidAppearance
     species: Moth
+    hideLayerOnEquip: 
+    - Hair
   - type: Hunger
   - type: Thirst
   - type: Icon

--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -17,6 +17,7 @@
   sprites:
     Head: MobMothHead
     Snout: MobHumanoidAnyMarking
+    Hair: MobHumanoidAnyMarking
     Chest: MobMothTorso
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
@@ -39,13 +40,12 @@
 
 - type: markingPoints
   id: MobMothMarkingLimits
-  onlyWhitelisted: true
   points:
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
-      points: 0
+      points: 1
       required: false
     Tail:
       points: 1
@@ -73,6 +73,9 @@
     Arms:
       points: 2
       required: false
+
+- type: humanoidBaseSprite
+  id: MobHumanoidAnyMarking
 
 - type: humanoidBaseSprite
   id: MobMothHead


### PR DESCRIPTION
Essas mudanças possibilita a customização de cabelo e barba para quem joga de Moth.

- Será possível adicionar cabelo e barba na customização de personagem durante o menu inicial, assim como alterar elas durante o jogo.