### PR TITLE
Correção de acesso para Promotor e novas traduções

### DIFF
--- a/Resources/Locale/pt-BR/paper/stamp-component.ftl
+++ b/Resources/Locale/pt-BR/paper/stamp-component.ftl
@@ -17,3 +17,7 @@ stamp-component-stamped-name-warden = Diretor de Segurança
 stamp-component-stamped-name-trader = Mercante
 stamp-component-stamped-name-syndicate = Sindicato
 stamp-component-stamped-name-ce = Engenheiro Chefe
+stamp-component-stamped-name-chiefjustice = Juiz Chefe
+stamp-component-stamped-name-notary = Escriturário.
+stamp-component-stamped-name-psychologist = Psicólogo
+stamp-component-stamped-name-mantis = Mantis

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -1707,7 +1707,7 @@
     - state: panel
       map: ["enum.WiresVisualLayers.MaintenancePanel"]
   - type: AccessReader
-    access: [["Lawyer"]]
+    access: [["Lawyer"], ["Prosecutor"]]
 
 - type: entity
   parent: VendingMachine


### PR DESCRIPTION
Corrigi que o promotor não tinha acesso a maquina do advogado.
Adicionei traduções novas para os carimbos que ainda não tinha.