### PR TITLE
Emotes para Cachorros e Gatos e Interação de cheirar

### DIFF
--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/animals.yml
@@ -71,6 +71,7 @@
     - Fox
     understands:
     - Fox
+  - type: ScentTracker
 
 - type: entity
   name: security dog
@@ -105,6 +106,11 @@
   - type: Speech
     speechVerb: Canine
     speechSounds: Vulpkanin
+  - type: Vocal
+    sounds:
+      Male: DogSounds
+      Female: DogSounds
+      Unsexed: DogSounds
   - type: Fixtures
     fixtures:
       fix1:
@@ -166,6 +172,7 @@
     interactSuccessSpawn: EffectHearts
     interactSuccessSound:
       path: /Audio/DeltaV/Voice/Vulpkanin/dog_bark2.ogg
+  - type: ScentTracker
   - type: Grammar
     attributes:
       gender: epicene
@@ -179,6 +186,7 @@
     tags:
     - DoorBumpOpener
     - VimPilot
+
   - type: LanguageKnowledge
     speaks:
     - Dog

--- a/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Mobs/NPCs/pets.yml
@@ -53,3 +53,4 @@
     - CannotSuicide
     - VimPilot
     - DoorBumpOpener
+

--- a/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/DeltaV/Voice/speech_emote_sounds.yml
@@ -136,3 +136,21 @@
       collection: VulpkaninWhines
     Howl:
       collection: VulpkaninHowls
+
+- type: emoteSounds
+  id: DogSounds
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: VulpkaninScreams
+    Growl:
+      collection: VulpkaninGrowls
+    Snarl:
+      collection: VulpkaninSnarls
+    Bark:
+      collection: VulpkaninBarks
+    Whine:
+      collection: VulpkaninWhines
+    Howl:
+      collection: VulpkaninHowls

--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2636,8 +2636,14 @@
       state: corgi
   - type: Carriable
   - type: Physics
+  - type: Vocal
+    sounds:
+      Male: DogSounds
+      Female: DogSounds
+      Unsexed: DogSounds
   - type: Speech
     speechVerb: Canine
+    speechSounds: Vulpkanin
   - type: Fixtures
     fixtures:
       fix1:
@@ -2668,11 +2674,13 @@
     spawned:
     - id: FoodMeat
       amount: 2
+  - type: ScentTracker
   - type: LanguageKnowledge
     speaks:
     - Dog
     understands:
     - Dog
+    - GalacticCommon
   - type: InteractionPopup
     interactSuccessString: petting-success-dog
     interactFailureString: petting-failure-generic
@@ -2703,6 +2711,7 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: narsian
+  - type: ScentTracker
   - type: DamageStateVisuals
     states:
       Alive:
@@ -2736,6 +2745,11 @@
       gender: epicene
   - type: Bloodstream
     bloodReagent: DemonsBlood
+  - type: Vocal
+    sounds:
+      Male: DogSounds
+      Female: DogSounds
+      Unsexed: DogSounds
   - type: Damageable
     damageContainer: CorporealSpirit # Nyanotrasen - Corporeal Spirit allows Holy water to do damage
     damageModifierSet: Infernal
@@ -2763,10 +2777,16 @@
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: puppy
+  - type: ScentTracker
   - type: Inventory
     speciesId: puppy
     templateId: pet
   - type: InventorySlots
+  - type: Vocal
+    sounds:
+      Male: DogSounds
+      Female: DogSounds
+      Unsexed: DogSounds
   - type: DamageStateVisuals
     states:
       Alive:
@@ -2822,6 +2842,11 @@
   - type: Speech
     speechSounds: Cat
     speechVerb: SmallMob
+  - type: Vocal
+    sounds:
+      Male: CatSounds
+      Female: CatSounds
+      Unsexed: CatSounds
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -2924,6 +2949,11 @@
   - type: Temperature
     heatDamageThreshold: 423
     coldDamageThreshold: 0
+  - type: Vocal
+    sounds:
+      Male: CatSounds
+      Female: CatSounds
+      Unsexed: CatSounds
   - type: PressureImmunity
   - type: InteractionPopup
     successChance: 0.7

--- a/Resources/Prototypes/Entities/Mobs/NPCs/dogs.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/dogs.yml
@@ -35,6 +35,12 @@
         - MobMask
         layer:
         - MobLayer
+  - type: Vocal
+    sounds:
+      Male: DogSounds
+      Female: DogSounds
+      Unsexed: DogSounds
+  - type: ScentTracker
   - type: Appearance
   - type: Inventory
     speciesId: dog
@@ -66,7 +72,6 @@
     interactSuccessSound:
       path: /Audio/Animals/small_dog_bark_happy.ogg
     hostileOnFail: true
-  - type: DogVision
   - type: NpcFactionMember
     factions:
     - Pibble

--- a/Resources/Prototypes/Nyanotrasen/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/Nyanotrasen/Voice/speech_emote_sounds.yml
@@ -74,3 +74,22 @@
       collection: FelinidGrowls
     Purr:
       collection: FelinidPurrs
+
+- type: emoteSounds
+  id: CatSounds
+  params:
+    variation: 0.125
+  sounds:
+    Scream:
+      collection: FelinidScreams
+    Hiss:
+      collection: FelinidHisses
+    Meow:
+      collection: FelinidMeows
+    Mew:
+      collection: FelinidMews
+    Growl:
+      collection: FelinidGrowls
+    Purr:
+      collection: FelinidPurrs
+


### PR DESCRIPTION
# Descrição

Eu adicionei a função de Vocal para os gatos e cachorros e seus sons criando id's de emoteSounds  CatSounds e DogSounds para cada um respectivamente, também adicionei a função de ScentTracker para os cachorros conseguirem sentir cheiro assim como os vulpkanins.

# TODO

- [x] Emotes para cães
- [x] Emotes para gatos
- [x] Cães conseguirem farejar

<details><summary><h1>Media</h1></summary>
<p>

![Laika Farejando Uma Luva](https://cdn.discordapp.com/attachments/1286809211228917760/1286809405987356713/dotnet_EpdgF0sum9.gif?ex=66ef4226&is=66edf0a6&hm=aa3f63d7e3d0c54d21ca78c4860fa5f5447d46f2506d32b3d80fcab8bc1d6d64&)
</p>
</details>

# Changelog

:cl: NSeiQNome
- add: Adicionado emotes para cães.
- add: Adicionado emotes para gatos.
- add: Adicionado mecânica de farejar para cães.
- tweak: Cães podem entender a língua galáctica comum.
- tweak: Pitbulls agora veem como qualquer outro cachorro.