### PR TITLE
Port das teclas de atalho para rotacionar e flippar objetos

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -76,6 +76,9 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OfferItem);
             human.AddFunction(ContentKeyFunctions.ToggleStanding);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
+            human.AddFunction(ContentKeyFunctions.RotateObjectClockwise);
+            human.AddFunction(ContentKeyFunctions.RotateObjectCounterclockwise);
+            human.AddFunction(ContentKeyFunctions.FlipObject);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);
             human.AddFunction(ContentKeyFunctions.ArcadeLeft);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -220,6 +220,9 @@ namespace Content.Client.Options.UI.Tabs
             AddButton(ContentKeyFunctions.MovePulledObject);
             AddButton(ContentKeyFunctions.ReleasePulledObject);
             AddButton(ContentKeyFunctions.Point);
+            AddButton(ContentKeyFunctions.RotateObjectClockwise);
+            AddButton(ContentKeyFunctions.RotateObjectCounterclockwise);
+            AddButton(ContentKeyFunctions.FlipObject);
 
             AddHeader("ui-options-header-ui");
             AddButton(ContentKeyFunctions.FocusChat);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -103,7 +103,6 @@ namespace Content.Client.Options.UI.Tabs
             _cfg.SetCVar(CCVars.HoldLookUp, args.Pressed);
             _cfg.SaveToFile();
         }
-        
         private void HandleDefaultWalk(BaseButton.ButtonToggledEventArgs args)
         {
             _cfg.SetCVar(CCVars.DefaultWalk, args.Pressed);

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -1,15 +1,15 @@
 using Content.Server.Popups;
-using Content.Shared.ActionBlocker;
-using Content.Shared.Input;
-using Content.Shared.Interaction;
+using Content.Shared.Popups;
 using Content.Shared.Rotatable;
 using Content.Shared.Verbs;
-using Robust.Shared.Input.Binding;
-using Robust.Shared.Map;
-using Robust.Shared.Player;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Utility;
+using Robust.Shared.Map;
+using Content.Shared.Input;
+using Content.Shared.ActionBlocker;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Player;
 
 namespace Content.Server.Rotatable
 {
@@ -20,7 +20,6 @@ namespace Content.Server.Rotatable
     {
         [Dependency] private readonly PopupSystem _popup = default!;
         [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
-        [Dependency] private readonly SharedInteractionSystem _interaction = default!;
 
         public override void Initialize()
         {
@@ -39,16 +38,12 @@ namespace Content.Server.Rotatable
             if (!args.CanAccess || !args.CanInteract)
                 return;
 
-            // Check if the object is anchored.
-            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) && physics.BodyType == BodyType.Static)
-                return;
-
             Verb verb = new()
             {
-                Act = () => Flip(uid, component),
+                Act = () => TryFlip(uid, component, args.User),
                 Text = Loc.GetString("flippable-verb-get-data-text"),
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/flip.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/flip.svg.192dpi.png")),
                 Priority = -3, // show flip last
                 DoContactInteraction = true
             };
@@ -59,61 +54,45 @@ namespace Content.Server.Rotatable
         {
             if (!args.CanAccess
                 || !args.CanInteract
-                || Transform(uid).NoLocalRotation) // Good ol prototype inheritance, eh?
+                || Transform(uid).NoLocalRotation)
                 return;
 
-            // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!component.RotateWhileAnchored &&
                 EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
                 return;
 
-            Verb resetRotation = new()
+            Verb resetRotation = new ()
             {
                 DoContactInteraction = true,
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation = Angle.Zero,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
                 Text = "Reset",
-                Priority = -2, // show CCW, then CW, then reset
+                Priority = -2,
                 CloseMenu = false,
             };
             args.Verbs.Add(resetRotation);
 
-            // rotate clockwise
             Verb rotateCW = new()
             {
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation -= component.Increment,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png")),
                 Priority = -1,
-                CloseMenu = false, // allow for easy double rotations.
+                CloseMenu = false,
             };
             args.Verbs.Add(rotateCW);
 
-            // rotate counter-clockwise
             Verb rotateCCW = new()
             {
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation += component.Increment,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png")),
                 Priority = 0,
-                CloseMenu = false, // allow for easy double rotations.
+                CloseMenu = false,
             };
             args.Verbs.Add(rotateCCW);
-        }
-
-        /// <summary>
-        ///     Replace a flippable entity with it's flipped / mirror-symmetric entity.
-        /// </summary>
-        public void Flip(EntityUid uid, FlippableComponent component)
-        {
-            var oldTransform = EntityManager.GetComponent<TransformComponent>(uid);
-            var entity = EntityManager.SpawnEntity(component.MirrorEntity, oldTransform.Coordinates);
-            var newTransform = EntityManager.GetComponent<TransformComponent>(entity);
-            newTransform.LocalRotation = oldTransform.LocalRotation;
-            newTransform.Anchored = false;
-            EntityManager.DeleteEntity(uid);
         }
 
         public bool HandleRotateObjectClockwise(ICommonSession? playerSession, EntityCoordinates coordinates, EntityUid entity)
@@ -124,10 +103,9 @@ namespace Content.Server.Rotatable
             if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity))
                 return false;
 
-            // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
             {
@@ -147,10 +125,9 @@ namespace Content.Server.Rotatable
             if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity))
                 return false;
 
-            // Check if the object is anchored, and whether we are still allowed to rotate it.
             if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
             {
@@ -170,18 +147,27 @@ namespace Content.Server.Rotatable
             if (!TryComp<FlippableComponent>(entity, out var flippableComp))
                 return false;
 
-            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+            if (!_actionBlocker.CanInteract(player, entity))
                 return false;
 
-            // Check if the object is anchored.
             if (EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) && physics.BodyType == BodyType.Static)
             {
                 _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
                 return false;
             }
 
-            Flip(entity, flippableComp);
+            TryFlip(entity, flippableComp, player);
             return true;
+        }
+
+        public void TryFlip(EntityUid uid, FlippableComponent component, EntityUid user)
+        {
+            var oldTransform = EntityManager.GetComponent<TransformComponent>(uid);
+            var entity = EntityManager.SpawnEntity(component.MirrorEntity, oldTransform.Coordinates);
+            var newTransform = EntityManager.GetComponent<TransformComponent>(entity);
+            newTransform.LocalRotation = oldTransform.LocalRotation;
+            newTransform.Anchored = false;
+            EntityManager.DeleteEntity(uid);
         }
     }
 }

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -41,10 +41,7 @@ namespace Content.Server.Rotatable
 
             // Check if the object is anchored.
             if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) && physics.BodyType == BodyType.Static)
-            {
-                _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), uid, args.User);
                 return;
-            }
 
             Verb verb = new()
             {
@@ -69,10 +66,7 @@ namespace Content.Server.Rotatable
             if (!component.RotateWhileAnchored &&
                 EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
-            {
-                _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), uid, args.User);
                 return;
-            }
 
             Verb resetRotation = new()
             {

--- a/Content.Server/Rotatable/RotatableSystem.cs
+++ b/Content.Server/Rotatable/RotatableSystem.cs
@@ -1,7 +1,12 @@
 using Content.Server.Popups;
-using Content.Shared.Popups;
+using Content.Shared.ActionBlocker;
+using Content.Shared.Input;
+using Content.Shared.Interaction;
 using Content.Shared.Rotatable;
 using Content.Shared.Verbs;
+using Robust.Shared.Input.Binding;
+using Robust.Shared.Map;
+using Robust.Shared.Player;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
 using Robust.Shared.Utility;
@@ -14,11 +19,19 @@ namespace Content.Server.Rotatable
     public sealed class RotatableSystem : EntitySystem
     {
         [Dependency] private readonly PopupSystem _popup = default!;
+        [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
+        [Dependency] private readonly SharedInteractionSystem _interaction = default!;
 
         public override void Initialize()
         {
             SubscribeLocalEvent<FlippableComponent, GetVerbsEvent<Verb>>(AddFlipVerb);
             SubscribeLocalEvent<RotatableComponent, GetVerbsEvent<Verb>>(AddRotateVerbs);
+
+            CommandBinds.Builder
+                .Bind(ContentKeyFunctions.RotateObjectClockwise, new PointerInputCmdHandler(HandleRotateObjectClockwise))
+                .Bind(ContentKeyFunctions.RotateObjectCounterclockwise, new PointerInputCmdHandler(HandleRotateObjectCounterclockwise))
+                .Bind(ContentKeyFunctions.FlipObject, new PointerInputCmdHandler(HandleFlipObject))
+                .Register<RotatableSystem>();
         }
 
         private void AddFlipVerb(EntityUid uid, FlippableComponent component, GetVerbsEvent<Verb> args)
@@ -26,12 +39,19 @@ namespace Content.Server.Rotatable
             if (!args.CanAccess || !args.CanInteract)
                 return;
 
+            // Check if the object is anchored.
+            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) && physics.BodyType == BodyType.Static)
+            {
+                _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), uid, args.User);
+                return;
+            }
+
             Verb verb = new()
             {
-                Act = () => TryFlip(uid, component, args.User),
+                Act = () => Flip(uid, component),
                 Text = Loc.GetString("flippable-verb-get-data-text"),
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/flip.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/flip.svg.192dpi.png")),
                 Priority = -3, // show flip last
                 DoContactInteraction = true
             };
@@ -49,14 +69,17 @@ namespace Content.Server.Rotatable
             if (!component.RotateWhileAnchored &&
                 EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
                 physics.BodyType == BodyType.Static)
+            {
+                _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), uid, args.User);
                 return;
+            }
 
-            Verb resetRotation = new ()
+            Verb resetRotation = new()
             {
                 DoContactInteraction = true,
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation = Angle.Zero,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/refresh.svg.192dpi.png")),
                 Text = "Reset",
                 Priority = -2, // show CCW, then CW, then reset
                 CloseMenu = false,
@@ -68,7 +91,7 @@ namespace Content.Server.Rotatable
             {
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation -= component.Increment,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rotate_cw.svg.192dpi.png")),
                 Priority = -1,
                 CloseMenu = false, // allow for easy double rotations.
             };
@@ -79,7 +102,7 @@ namespace Content.Server.Rotatable
             {
                 Act = () => EntityManager.GetComponent<TransformComponent>(uid).LocalRotation += component.Increment,
                 Category = VerbCategory.Rotate,
-                Icon = new SpriteSpecifier.Texture(new ("/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png")),
+                Icon = new SpriteSpecifier.Texture(new("/Textures/Interface/VerbIcons/rotate_ccw.svg.192dpi.png")),
                 Priority = 0,
                 CloseMenu = false, // allow for easy double rotations.
             };
@@ -89,21 +112,82 @@ namespace Content.Server.Rotatable
         /// <summary>
         ///     Replace a flippable entity with it's flipped / mirror-symmetric entity.
         /// </summary>
-        public void TryFlip(EntityUid uid, FlippableComponent component, EntityUid user)
+        public void Flip(EntityUid uid, FlippableComponent component)
         {
-            if (EntityManager.TryGetComponent(uid, out PhysicsComponent? physics) &&
-                physics.BodyType == BodyType.Static)
-            {
-                _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), uid, user);
-                return;
-            }
-
             var oldTransform = EntityManager.GetComponent<TransformComponent>(uid);
             var entity = EntityManager.SpawnEntity(component.MirrorEntity, oldTransform.Coordinates);
             var newTransform = EntityManager.GetComponent<TransformComponent>(entity);
             newTransform.LocalRotation = oldTransform.LocalRotation;
             newTransform.Anchored = false;
             EntityManager.DeleteEntity(uid);
+        }
+
+        public bool HandleRotateObjectClockwise(ICommonSession? playerSession, EntityCoordinates coordinates, EntityUid entity)
+        {
+            if (playerSession?.AttachedEntity is not { Valid: true } player || !Exists(player))
+                return false;
+
+            if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
+                return false;
+
+            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+                return false;
+
+            // Check if the object is anchored, and whether we are still allowed to rotate it.
+            if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
+                physics.BodyType == BodyType.Static)
+            {
+                _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+                return false;
+            }
+
+            Transform(entity).LocalRotation -= rotatableComp.Increment;
+            return true;
+        }
+
+        public bool HandleRotateObjectCounterclockwise(ICommonSession? playerSession, EntityCoordinates coordinates, EntityUid entity)
+        {
+            if (playerSession?.AttachedEntity is not { Valid: true } player || !Exists(player))
+                return false;
+
+            if (!TryComp<RotatableComponent>(entity, out var rotatableComp))
+                return false;
+
+            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+                return false;
+
+            // Check if the object is anchored, and whether we are still allowed to rotate it.
+            if (!rotatableComp.RotateWhileAnchored && EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) &&
+                physics.BodyType == BodyType.Static)
+            {
+                _popup.PopupEntity(Loc.GetString("rotatable-component-try-rotate-stuck"), entity, player);
+                return false;
+            }
+
+            Transform(entity).LocalRotation += rotatableComp.Increment;
+            return true;
+        }
+
+        public bool HandleFlipObject(ICommonSession? playerSession, EntityCoordinates coordinates, EntityUid entity)
+        {
+            if (playerSession?.AttachedEntity is not { Valid: true } player || !Exists(player))
+                return false;
+
+            if (!TryComp<FlippableComponent>(entity, out var flippableComp))
+                return false;
+
+            if (!_actionBlocker.CanInteract(player, entity) || !_interaction.InRangeAndAccessible(player, entity))
+                return false;
+
+            // Check if the object is anchored.
+            if (EntityManager.TryGetComponent(entity, out PhysicsComponent? physics) && physics.BodyType == BodyType.Static)
+            {
+                _popup.PopupEntity(Loc.GetString("flippable-component-try-flip-is-stuck"), entity, player);
+                return false;
+            }
+
+            Flip(entity, flippableComp);
+            return true;
         }
     }
 }

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -43,6 +43,9 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction MovePulledObject = "MovePulledObject";
         public static readonly BoundKeyFunction ReleasePulledObject = "ReleasePulledObject";
         public static readonly BoundKeyFunction MouseMiddle = "MouseMiddle";
+        public static readonly BoundKeyFunction RotateObjectClockwise = "RotateObjectClockwise";
+        public static readonly BoundKeyFunction RotateObjectCounterclockwise = "RotateObjectCounterclockwise";
+        public static readonly BoundKeyFunction FlipObject = "FlipObject";
         public static readonly BoundKeyFunction ToggleRoundEndSummaryWindow = "ToggleRoundEndSummaryWindow";
         public static readonly BoundKeyFunction OpenEntitySpawnWindow = "OpenEntitySpawnWindow";
         public static readonly BoundKeyFunction OpenSandboxWindow = "OpenSandboxWindow";

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -158,6 +158,9 @@ ui-options-function-try-pull-object = Pull object
 ui-options-function-move-pulled-object = Move pulled object
 ui-options-function-release-pulled-object = Release pulled object
 ui-options-function-point = Point at location
+ui-options-function-rotate-object-clockwise = Rotate clockwise
+ui-options-function-rotate-object-counterclockwise = Rotate counterclockwise
+ui-options-function-flip-object = Flip
 
 ui-options-function-focus-chat-input-window = Focus chat
 ui-options-function-focus-local-chat-window = Focus chat (IC)

--- a/Resources/Locale/pt-BR/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/pt-BR/escape-menu/ui/options-menu.ftl
@@ -158,6 +158,9 @@ ui-options-function-try-pull-object = Puxar objeto
 ui-options-function-move-pulled-object = Mover objeto puxado
 ui-options-function-release-pulled-object = Soltar objeto puxado
 ui-options-function-point = Apontar para local
+ui-options-function-rotate-object-clockwise = Rotacionar no sentido horário
+ui-options-function-rotate-object-counterclockwise = Rotacionar no sentido anti-horário
+ui-options-function-flip-object = Inverter
 
 ui-options-function-focus-chat-input-window = Foco no Chat
 ui-options-function-focus-local-chat-window = Foco no Chat (IC)

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -275,6 +275,16 @@ binds:
   type: State
   key: MouseMiddle
   canFocus: true
+- function: RotateObjectClockwise
+  type: State
+  key: R
+- function: RotateObjectCounterclockwise
+  type: State
+  key: R
+  mod1: Shift
+- function: FlipObject
+  type: State
+  key: F
 - function: TextCursorLeft
   type: State
   key: Left

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -278,13 +278,15 @@ binds:
 - function: RotateObjectClockwise
   type: State
   key: R
+  mod1: Shift
 - function: RotateObjectCounterclockwise
   type: State
   key: R
-  mod1: Shift
+  mod1: Control
 - function: FlipObject
   type: State
   key: F
+  mod1: Shift
 - function: TextCursorLeft
   type: State
   key: Left


### PR DESCRIPTION
## Introdução

Adiciona atalhos de teclado para girar e flippar objetos. Anteriormente, isso só era acessível através do menu de interação acessado pelo right click.

## Motivo

Uma função que simplifica a construção de um setup atmosférico ou da Particle Accelerator, ja que o processo costumava ser demorado.

## Mudanças

Adiciona as teclas de Rotacionar e Flippar objetos na aba Controles em Configurações, ja vem definidas como Shift+R (girar sentido horário), Control+R (girar sentido anti-horário), Shift-F (flippar).

## Changelog

- Atualiza ContentContexts.cs
- Atualiza KeyRebindTab.xaml.cs
- Atualiza RotatableSystem.cs
- Atualiza ContentKeyFunctions.cs
- Atualiza keybinds.yml
- Atualiza options-menu.ftl


## Media

https://github.com/user-attachments/assets/36775369-1607-45de-ae0e-c95c61d00cf8

